### PR TITLE
Fix problems with DS18B20 driver used with DS248x

### DIFF
--- a/src/Slaves/Sensors/DS18B20/DS18B20.cpp
+++ b/src/Slaves/Sensors/DS18B20/DS18B20.cpp
@@ -128,12 +128,12 @@ OneWireSlave::CmdResult DS18B20::readPowerSupply(bool & localPower)
         owmResult = master().OWWriteByteSetLevel(READ_POWER_SUPPY, OneWireMaster::NormalLevel);
         if(owmResult == OneWireMaster::Success)
         {
-            uint8_t rtnBit = 0;
+            uint8_t rtnBit = 1;
             
             owmResult = master().OWTouchBitSetLevel(rtnBit, OneWireMaster::NormalLevel);
             if(owmResult == OneWireMaster::Success)
             {
-                localPower = (rtnBit & 0x01);
+                localPower = !!rtnBit;
                 deviceResult = OneWireSlave::Success;
             }
             else
@@ -242,14 +242,15 @@ OneWireSlave::CmdResult DS18B20::convertTemperature(float & temp)
                 owmResult = master().OWWriteByteSetLevel(CONV_TEMPERATURE, OneWireMaster::NormalLevel); 
                 if (owmResult == OneWireMaster::Success)
                 {
-                    uint8_t recvbit = 0;
+                    uint8_t recvbit;
                     do
                     {
+                        recvbit = 1;
                         owmResult = master().OWTouchBitSetLevel(recvbit, OneWireMaster::NormalLevel);
                     }
                     while((owmResult == OneWireMaster::Success) && (!recvbit));
                     
-                    if((owmResult == OneWireMaster::Success) && (recvbit & 1))
+                    if((owmResult == OneWireMaster::Success) && !!recvbit)
                     {
                         deviceResult = this->readScratchPad(scratchPadBuff);
                     }

--- a/src/Slaves/Sensors/DS18B20/DS18B20.cpp
+++ b/src/Slaves/Sensors/DS18B20/DS18B20.cpp
@@ -169,14 +169,15 @@ OneWireSlave::CmdResult DS18B20::copyScratchPad( void )
                 owmResult = master().OWWriteByteSetLevel(COPY_SCRATCHPAD, OneWireMaster::NormalLevel); 
                 if (owmResult == OneWireMaster::Success)
                 {
-                    uint8_t recvbit = 0;
+                    uint8_t recvbit;
                     do
                     {
+                        recvbit = 1;
                         owmResult = master().OWTouchBitSetLevel(recvbit, OneWireMaster::NormalLevel);
                     }
                     while((!recvbit) && (owmResult == OneWireMaster::Success));
                     
-                    if ((owmResult == OneWireMaster::Success) && (recvbit & 1))
+                    if ((owmResult == OneWireMaster::Success) && !!recvbit)
                     {
                         deviceResult = OneWireSlave::Success;
                     }


### PR DESCRIPTION
DS18B20 driver did not work correctly when used with DS248x (I2C to 1-wire) driver. There were two issues:

Firstly, rtnBit passed as a parameter to OWTouchBitSetLevel() is is used as the value driven on to the bus by the master prior to the read, as well as being used as the return value. It must be initialised to 1, not 0, else the slave will not be able to reply with a 1.

Second, the value returned by OWTouchBitSetLevel() in rtnBit is not a Bool. It takes the values 0x00 or 0x20 since it is just the status register SBR bit (see DS248x.cpp line 244). So the (rtnBit & 1) test is always false. I converted to Bool with double negation rather than bitwise and. This issue could also have been fixed by having OWTouchBitSetLevel() return 0 or 1, which might be cleaner.

I updated similar code in DS18B20::readPowerSupply(), DS18B20::copyScratchPad() and DS18B20::convertTemperature().